### PR TITLE
Fix permision error

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -22,7 +22,7 @@ In order to test and develop on your local machine, you can use a specially buil
 +
 [source,sh]
 ----
-podman run --rm --name antora -v $PWD:/antora -p 8080:8080 -i -t ghcr.io/juliaaano/antora-viewer
+podman run --rm --name antora -v $PWD:/antora:Z -p 8080:8080 -i -t ghcr.io/juliaaano/antora-viewer
 ----
 
 Live-reload is not supported.


### PR DESCRIPTION
Got the following error trying to test on Fedora 38...

```
FATAL (antora): EACCES: permission denied, open '/antora/default-site.yml' in /antora/default-site.yml (cwd: /antora, playbook: default-site.yml)
```

It's because of SELinux, of course. Adding `:Z` option fixes it. Cheers!